### PR TITLE
feat: update report definition response body update

### DIFF
--- a/mappings/reports/update-report-definition/Report - Update Report Definition Response Body All Properties.json
+++ b/mappings/reports/update-report-definition/Report - Update Report Definition Response Body All Properties.json
@@ -48,17 +48,6 @@
             "isExpanded": true
           }
         ],
-        "aggregationCriteria": [
-          {
-            "column": {
-              "title": "Primary Column",
-              "type": "TEXT_NUMBER",
-              "primary": true
-            },
-            "aggregationType": "COUNT",
-            "isExpanded": true
-          }
-        ],
         "sortingCriteria": [
           {
             "column": {
@@ -67,6 +56,17 @@
               "primary": true
             },
             "sortingDirection": "ASCENDING"
+          }
+        ],
+        "summarizingCriteria": [
+          {
+            "column": {
+              "title": "Primary Column",
+              "type": "TEXT_NUMBER",
+              "primary": true
+            },
+            "aggregationType": "COUNT",
+            "isExpanded": true
           }
         ]
       }

--- a/mappings/reports/update-report-definition/Report - Update Report Definition Response Body All Properties.json
+++ b/mappings/reports/update-report-definition/Report - Update Report Definition Response Body All Properties.json
@@ -19,7 +19,57 @@
     "status": 200,
     "jsonBody": {
       "message": "SUCCESS",
-      "resultCode": 0
+      "resultCode": 0,
+      "result": {
+        "filters": {
+          "operator": "AND",
+          "criteria": [
+            {
+              "column": {
+                "title": "Primary Column",
+                "type": "TEXT_NUMBER",
+                "primary": true
+              },
+              "operator": "EQUAL",
+              "values": [
+                "Test"
+              ]
+            }
+          ]
+        },
+        "groupingCriteria": [
+          {
+            "column": {
+              "title": "Primary Column",
+              "type": "TEXT_NUMBER",
+              "primary": true
+            },
+            "sortingDirection": "ASCENDING",
+            "isExpanded": true
+          }
+        ],
+        "aggregationCriteria": [
+          {
+            "column": {
+              "title": "Primary Column",
+              "type": "TEXT_NUMBER",
+              "primary": true
+            },
+            "aggregationType": "COUNT",
+            "isExpanded": true
+          }
+        ],
+        "sortingCriteria": [
+          {
+            "column": {
+              "title": "Primary Column",
+              "type": "TEXT_NUMBER",
+              "primary": true
+            },
+            "sortingDirection": "ASCENDING"
+          }
+        ]
+      }
     },
     "headers": {
       "Content-Type": "application/json"


### PR DESCRIPTION
Update wiremock test for PATCH /2.0/reports/{reportId}/definition to include the updated response with a simplified report definition object instead of just the generic response