### PR TITLE
feat: change update definition to PUT

### DIFF
--- a/mappings/reports/update-report-definition/Report - Update Report Definition Response Body All Properties.json
+++ b/mappings/reports/update-report-definition/Report - Update Report Definition Response Body All Properties.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "urlPathTemplate": "/2.0/reports/{reportId}/definition",
-    "method": "PATCH",
+    "method": "PUT",
     "headers": {
       "Authorization": {
         "matches": "Bearer .*"


### PR DESCRIPTION
Request endpoint PUT /2.0/reports/{reportId}/definition has been changed to PUT /2.0/reports/{reportId}/definition

This endpoint is currently not included in the public API and will be added in the future, tests are being updated to aid with development of SDKs