### PR TITLE
fix: add Content-Type header to event list stubs

### DIFF
--- a/mappings/events/list-events/Event - List Events Response Body All Properties.json
+++ b/mappings/events/list-events/Event - List Events Response Body All Properties.json
@@ -17,6 +17,9 @@
   "response": {
     "statusMessage": "OK",
     "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
     "jsonBody": {
       "moreAvailable": false,
       "data": [

--- a/mappings/events/list-events/Event - List Events Response Body Required Properties.json
+++ b/mappings/events/list-events/Event - List Events Response Body Required Properties.json
@@ -17,6 +17,9 @@
   "response": {
     "statusMessage": "OK",
     "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
     "jsonBody": {
       "moreAvailable": true,
       "nextStreamPosition": "2.1.Y-oF8RMroSCo4WLS9p78QEz-LXzzzzzzjnXA2hFnCN_w",


### PR DESCRIPTION
## Summary
 
Adds the missing `Content-Type: application/json` response header to the event list WireMock stubs. Without this header, the Java SDK's Apache HTTP client returns a null content type, causing a `NullPointerException` in `DefaultHttpClient` when the stubs are exercised by the contract tests.
 
## Changes
 
- Added explicit `Content-Type: application/json` response header to both event list stubs, matching the pattern already used by every other stub in this repo
## How to test
 
These stubs are exercised by `TestListEvents` in the Java SDK. Once the SDK PR is merged alongside this fix, the contract test job should pass cleanly.