### PR TITLE
Add planName to List User Plans all-properties mapping

### DIFF
--- a/mappings/users/list-user-plans/User - List User Plans Response Body All Properties.json
+++ b/mappings/users/list-user-plans/User - List User Plans Response Body All Properties.json
@@ -22,6 +22,7 @@
       "data": [
         {
           "planId": 1234567890123456,
+          "planName": "Acme Corporation",
           "seatType": "MEMBER",
           "seatTypeLastChangedAt": "2025-01-01T00:00:00.123456789Z",
           "provisionalExpirationDate": "2026-12-13T12:17:52.525696Z",


### PR DESCRIPTION
Closes #49

## Problem

`GET /2.0/users/{userId}/plans` gained an optional `include=planNames` query parameter. When passed, each returned plan carries `planName` — the name of the organization that owns the plan.

The all-response-body-properties mapping for this endpoint did not include that field. Since that case is meant to carry every property so SDKs can verify deserialization, any SDK test asserting `planName` fails on a field the mock does not return. This blocks the corresponding change in all four SDKs (Java, C#, JavaScript, Python).

## Solution

One line — `planName` added to the all-properties mapping:

```json
"data": [
  {
    "planId": 1234567890123456,
    "planName": "Acme Corporation",
    ...
```

**Only the all-properties mapping changes.** `planName` is optional — absent unless the enrichment is requested, and also absent when the owning organization has no name — so the required-response-body-properties case correctly omits it and SDKs assert null/undefined there.

The second plan in the all-properties mapping is deliberately left without a `planName`, which gives every SDK a free "enrichment absent" case alongside the populated one.

## Conformance with CONTRIBUTING.md

- **No new mapping file** and **no `include` request matcher** — mappings must not match on request body or query params, since query verification is done client-side via `x-request-id`.
- Nothing added under `mappings/scenarios/` (legacy).
- Consequence worth stating plainly: this mapping returns `planName` regardless of whether `include` was sent. The SDK tests therefore verify that the parameter is *sent* correctly and that the field *deserializes* correctly, but not the server-side conditionality of the enrichment. That matches the guidance that Wiremock tests should not cover response variations due to query parameter values — the conditional behaviour is verified at the service layer instead.

## Testing

Verified locally by running WireMock from this branch (`docker compose up -d`) and confirming the mapping serves `planName: "Acme Corporation"` on the first plan and omits it on the second. The four SDK branches were then tested against it — full suites green in each:

| SDK | Result |
|---|---|
| Python | 331 passed, 9 skipped (pre-existing) |
| Java | 181 mock + 662 unit passed, 3 skipped (pre-existing) |
| C# | 399 passed, 1 skipped (pre-existing) |
| JavaScript | 2084 passed, 0 skipped |

## Merge order

This should merge **before** the four SDK PRs. Each SDK CI job clones `smartsheet/smartsheet-sdk-tests` at its default branch, so until this lands their new assertions read a mapping without `planName` and fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mocked user plan data to include a plan name for the first user plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->